### PR TITLE
[기록] 인증 없이 기록 화면 전환시, 로그인 화면 거치도록 수정

### DIFF
--- a/src/app/(with-container)/record/page.tsx
+++ b/src/app/(with-container)/record/page.tsx
@@ -1,8 +1,22 @@
 import { Stack } from "@mui/material";
 import RecentRecordSection from "./panel/RecentRecordSection";
 import PastRecordsSection from "./panel/PastRecordsSection";
+import { redirect } from "next/navigation";
+import { isAuthError } from "@/apis/errors";
+import { createAxiosServer } from "@/apis/createAxiosServer";
 
-export default function Record() {
+export default async function Record() {
+  try {
+    const api = await createAxiosServer();
+    await api.get("/records");
+  } catch (e) {
+    if (isAuthError(e)) {
+      const next = encodeURIComponent("/record");
+      redirect(`/login?next=${next}`);
+    }
+    throw e;
+  }
+
   return (
     <Stack spacing={3}>
       <RecentRecordSection />

--- a/src/app/(with-container)/record/panel/RecordsList.tsx
+++ b/src/app/(with-container)/record/panel/RecordsList.tsx
@@ -57,7 +57,6 @@ export default function RecordsList({ variant, all }: Props) {
 
   return (
     <Card
-      variant={"outlined"}
       sx={{
         p: 0,
         borderRadius: isPhone ? 0 : "12px",

--- a/src/app/(with-container)/record/panel/SurveyActionButton.tsx
+++ b/src/app/(with-container)/record/panel/SurveyActionButton.tsx
@@ -26,7 +26,7 @@ type Props = {
   afterSaveHref?: string;
   gap?: number;
   alignRight?: boolean;
-  mobileStepper?: StepperProps; // ← 추가
+  mobileStepper?: StepperProps;
 };
 
 export default function SurveyActionButton({
@@ -54,18 +54,33 @@ export default function SurveyActionButton({
 
       const payload = elders.map((e) => {
         const p = pending[e.surveyId];
-        const rawParts = p?.troubleParts ?? e.troubleParts ?? [];
-        const mappedParts = rawParts.map(
-          (part) => troublePartMap[part] ?? part,
-        );
+
+        const hadTrouble = (p?.hadTrouble ?? e.hadTrouble) === true;
+
+        // 불편함이 없다면 parts는 무조건 빈 배열
+        const rawParts = hadTrouble
+          ? (p?.troubleParts ?? e.troubleParts ?? [])
+          : [];
+
+        const mappedParts = rawParts
+          .map((part) => troublePartMap[part])
+          .filter(Boolean) as string[];
+
         return {
           surveyId: e.surveyId,
           troubleParts: mappedParts,
           attitudeScore: p?.attitudeScore ?? e.attitudeScore,
           abilityScore: p?.abilityScore ?? e.abilityScore,
-          hadTrouble: p?.hadTrouble ?? e.hadTrouble,
+          hadTrouble,
+          memo: (p?.memo ?? e.memo ?? "").trim(),
         };
       });
+
+      console.log(
+        "[Survey] PUT /records/%s/surveys payload:",
+        recordId,
+        JSON.stringify(payload, null, 2),
+      );
 
       await axiosClient.put(`/records/${recordId}/surveys`, payload);
     },
@@ -73,7 +88,7 @@ export default function SurveyActionButton({
       qc.invalidateQueries({ queryKey: ["surveys", recordId] });
       router.push(afterSaveHref);
     },
-    onError: (error) => {
+    onError: (error: unknown) => {
       if (error instanceof isAuthError) {
         router.push("/login");
         return;

--- a/src/app/(with-container)/record/panel/SurveyElderCard.tsx
+++ b/src/app/(with-container)/record/panel/SurveyElderCard.tsx
@@ -33,6 +33,7 @@ export type Elder = {
   abilityScore: number;
   hadTrouble: boolean;
   updatedAt?: string;
+  memo?: string;
 };
 
 type PresetTrouble = { hasDiscomfort: "none" | "yes"; parts: string[] };
@@ -221,7 +222,7 @@ export default function ElderSurveyCard({
                     setTrouble(v);
                     bubble({
                       hadTrouble: v.hasDiscomfort === "yes",
-                      troubleParts: v.parts,
+                      troubleParts: v.hasDiscomfort === "yes" ? v.parts : [],
                     });
                   }}
                 />

--- a/src/app/(with-container)/record/panel/SurveyElderCard.tsx
+++ b/src/app/(with-container)/record/panel/SurveyElderCard.tsx
@@ -54,7 +54,7 @@ export type ElderUpdatePayload = {
   memo?: string;
 };
 
-type FormValues = { memo: string };
+type FormValues = { [key: string]: string };
 
 export default function ElderSurveyCard({
   elder,
@@ -64,7 +64,7 @@ export default function ElderSurveyCard({
   presetTrouble,
   step,
 }: Props) {
-  const { control } = useFormContext<FormValues>();
+  const { control, getValues } = useFormContext<FormValues>();
 
   const scaleFromScore = (s?: number): Scale => {
     switch (s) {
@@ -88,7 +88,6 @@ export default function ElderSurveyCard({
     hasDiscomfort: elder.hadTrouble ? "yes" : "none",
     parts: elder.troubleParts ?? [],
   });
-  const [memo, setMemo] = useState("");
 
   const { isPhone, isTablet } = useMedia();
   const infoVariant = isPhone
@@ -98,13 +97,16 @@ export default function ElderSurveyCard({
       : "Heading1";
 
   // 각 입력이 바뀔 때마다 상위에 변화를 올려줘서 "작성완료" 시 최신 상태를 보낼 수 있게 함
+  const fieldName = `memo-${elder.surveyId}`;
+
   const bubble = (next?: Partial<ElderUpdatePayload>) => {
+    const currentMemo = getValues(fieldName) || "";
     onChange(elder.surveyId, {
       attitudeScore: scoreOf[att],
       abilityScore: scoreOf[abl],
       hadTrouble: trouble.hasDiscomfort === "yes",
       troubleParts: trouble.parts,
-      memo,
+      memo: currentMemo,
       ...next,
     });
   };
@@ -230,11 +232,10 @@ export default function ElderSurveyCard({
         {/* 메모 */}
         <Box sx={{ mt: 1, width: "100%" }}>
           <SenifitTextField
-            name={"memo"}
+            name={`memo-${elder.surveyId}`}
             control={control}
             placeholder={"특이사항이 있다면 메모를 작성해주세요. (선택사항)"}
             onChange={(e) => {
-              setMemo(e.target.value);
               bubble({ memo: e.target.value });
             }}
             formControlProps={{

--- a/src/app/(with-container)/record/panel/SurveySection.tsx
+++ b/src/app/(with-container)/record/panel/SurveySection.tsx
@@ -3,7 +3,7 @@
 import { Box, Collapse, Typography, Divider, IconButton } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import SurveyElderCard, { Elder, ElderUpdatePayload } from "./SurveyElderCard";
 import SelectorCard from "./SelectorCard";
@@ -18,12 +18,12 @@ type Mode = "write" | "detail" | "update";
 
 type Props = { recordId: number; mode: Mode };
 
-type FormValues = { memo?: string };
+type FormValues = { [key: string]: string };
 
 export default function SurveySection({ recordId, mode }: Props) {
   const { isPhone, isTablet } = useMedia();
 
-  const methods = useForm<FormValues>({ defaultValues: { memo: "" } });
+  const methods = useForm<FormValues>({ defaultValues: {} });
 
   // 타이틀 분기
   const bigTitleVariant = isPhone
@@ -63,9 +63,47 @@ export default function SurveySection({ recordId, mode }: Props) {
       });
       if (!res.ok) throw new Error(`[${res.status}] ${res.statusText}`);
       const json = await res.json();
-      return (json?.data?.surveys as Elder[]) ?? [];
+
+      console.log("GET /api/records/" + recordId + "/surveys response:", json);
+
+      const reverseTroublePartMap: Record<string, string> = {
+        workout_kinds_calisthenic_targets_shoulders: "어깨",
+        workout_kinds_calisthenic_targets_arms: "팔",
+        workout_kinds_calisthenic_targets_legs: "다리",
+        workout_kinds_calisthenic_targets_back: "등",
+        workout_kinds_calisthenic_targets_abs: "배",
+      };
+
+      const surveys = (json?.data?.surveys ?? []).map((s: unknown) => {
+        const raw = s as {
+          troubleParts?: (string | { target: string })[];
+          memo?: string;
+        } & Elder;
+
+        // 서버 troubleParts → 한글 배열로 변환
+        const normalizedParts = Array.isArray(raw.troubleParts)
+          ? raw.troubleParts
+              .map((p) => (typeof p === "string" ? p : p.target))
+              .map((code) => reverseTroublePartMap[code] || code)
+              .filter(Boolean)
+          : [];
+
+        return {
+          ...raw,
+          troubleParts: normalizedParts,
+        };
+      });
+
+      return surveys as Elder[];
     },
   });
+
+  useEffect(() => {
+    const defaults = Object.fromEntries(
+      elders.map((e) => [`memo-${e.surveyId}`, e.memo ?? ""]),
+    );
+    methods.reset(defaults);
+  }, [elders, methods]);
 
   const handleChange = (surveyId: number, payload: ElderUpdatePayload) =>
     setPending((prev) => ({ ...prev, [surveyId]: payload }));

--- a/src/app/(with-container)/record/panel/server/getRecords.ts
+++ b/src/app/(with-container)/record/panel/server/getRecords.ts
@@ -1,29 +1,31 @@
 import { createAxiosServer } from "@/apis/createAxiosServer";
-import { mockRecords } from "../../utils/record.mock";
 import type { RecordItem } from "../../utils/recordUtils";
+import { isAuthError, AuthError } from "@/apis/errors";
+import type { AxiosError } from "axios";
 
 type RecordAPI = { status: number; message: string; data: RecordItem[] };
 
-const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
-
 export async function getRecordsServer(): Promise<RecordItem[]> {
-  if (USE_MOCK) return mockRecords;
-
   try {
     const api = await createAxiosServer();
     const { data } = await api.get<RecordAPI>("/records");
     return data?.data ?? [];
-  } catch {
-    console.log("getRecords 실패");
-    return mockRecords;
+  } catch (e: unknown) {
+    // 1) 인터셉터에서 AuthError로 던진 경우
+    if (isAuthError(e)) throw e;
+
+    // 2) AxiosError 타입으로 단언 후 status 꺼내기
+    const axiosErr = e as AxiosError;
+    const status = axiosErr.response?.status;
+    if (status === 401 || status === 403) throw new AuthError("/login");
+
+    // 3) 그 외 에러는 그대로 던짐
+    console.error("getRecords 실패", e);
+    throw e;
   }
 }
 
 export async function getRecordServer(id: number): Promise<RecordItem | null> {
-  if (process.env.NEXT_PUBLIC_USE_MOCK === "true") {
-    console.log("getRecords null 반환");
-    return null;
-  }
   const api = await createAxiosServer(); // 서버에서만 실행됨
   const { data } = await api.get<RecordAPI>("/records");
   return data?.data?.find((r) => r.recordId === id) ?? null;


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [ ]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [x]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?

> 변경된 기능 혹은 주요 작업 내용을 한두 문장으로 요약해주세요.
> 로그인 없이 바로 기록 탭 클릭 시, 로그인 화면으로 이동하지 않고 목 데이터가 뜨는 버그 수정하였습니다.
> 또한, "운동 중 불편함" 과 메모 입력에 대해서 설문한 값이 적용되지 않는 버그 수정하였습니다.
<img width="719" height="569" alt="image" src="https://github.com/user-attachments/assets/5e18a150-987e-4c2c-8a02-014e71219c16" />


&nbsp;
### 🔍 작업 상세 내용

- [ ]  작업1
    - record의 page.tsx에서 try catch 구문 사용
- [ ]  작업2
    - 어르신들 메모 내용이 다같이 공유되는 버그를 해결. 각 필드마다 이름을 다르게 설정하여 해결.
- [ ]  작업3
    - "운동 중 불편함"에 대해서 부위 선택 후 저장을 했음에도 불구하고, 다시 접속하였을 때 해당 부위가 체크되어 있지 않는 버그를 해결
- [ ] 작업4
    - 메모 입력 관련하여, api 키 값중에 memo 라는 것이 없어서 memo를 입력해도 수정되거나 받아오지 못하여서, 백엔드 분과 소통 후 api 수정하였고, 메모 관련해서도 수정 완료했습니다.

&nbsp;
### 💬 리뷰어에게 전달할 내용 (선택)

> 테스트 방법, 주의 깊게 봐줬으면 하는 부분 등
> 
