### PR TITLE
[기록] 운동 루틴 썸네일 사진 보이는 ui 추가

### DIFF
--- a/src/app/(with-container)/record/detail/[id]/page.tsx
+++ b/src/app/(with-container)/record/detail/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getRecordServer } from "../../panel/server/getRecords";
 import SurveySection from "../../panel/SurveySection";
 import BackActionButton from "../../panel/BackActionButton";
 import SurveyIntro from "../../panel/SurveyIntro";
+import RoutineImage from "../../panel/RoutineImage";
 
 export default async function RecordDetailPage({
   params,
@@ -19,6 +20,8 @@ export default async function RecordDetailPage({
 
       <AboutRecording record={currentRecord} title={"수업 정보"} />
 
+      <RoutineImage routines={currentRecord?.routines ?? []} />
+
       <Box
         sx={{
           p: 6,
@@ -28,7 +31,7 @@ export default async function RecordDetailPage({
           mb: 8,
         }}
       >
-        <SurveyIntro />
+        <SurveyIntro title={"수업 기록 확인하기"} />
 
         <Divider sx={{ my: 3 }} />
 

--- a/src/app/(with-container)/record/panel/RoutineImage.tsx
+++ b/src/app/(with-container)/record/panel/RoutineImage.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { useRef, useMemo } from "react";
+import RightIcon from "@/components/icons/RightIcon";
+import LeftIcon from "@/components/icons/LeftIcon";
+import useMedia from "@/hooks/useMedia";
+
+type Routine = {
+  id: number;
+  name: string;
+  thumbnail_path: string;
+};
+
+export default function RoutineImage({ routines }: { routines: Routine[] }) {
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+
+  const hasScroll = useMemo(() => (routines?.length ?? 0) > 0, [routines]);
+
+  const scrollBy = (delta: number) => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    el.scrollBy({ left: delta, behavior: "smooth" });
+  };
+
+  // 모바일에서는 숨김, 태블릿/데스크탑에서만 표시
+  const { isPhone } = useMedia();
+  if (isPhone) return null;
+
+  return (
+    <Box
+      sx={{
+        display: { xs: "none", sm: "block" },
+        position: "relative",
+        p: 4,
+        gap: 4,
+        borderRadius: "12px",
+        background: (t) => t.palette.bg?.normal ?? t.palette.background.paper,
+        boxShadow: "0 0 8px 0 rgba(12, 13, 13, 0.05)",
+        overflow: "hidden",
+      }}
+    >
+      {/* 좌우 화살표 */}
+      {hasScroll && (
+        <>
+          <Box
+            onClick={() => scrollBy(-320)}
+            sx={{
+              position: "absolute",
+              top: "50%",
+              left: 16,
+              transform: "translateY(-50%)",
+              cursor: "pointer",
+              zIndex: 1,
+            }}
+            aria-label={"scroll left"}
+          >
+            <LeftIcon />
+          </Box>
+
+          <Box
+            onClick={() => scrollBy(320)}
+            sx={{
+              position: "absolute",
+              top: "50%",
+              right: 16,
+              transform: "translateY(-50%)",
+              cursor: "pointer",
+              zIndex: 1,
+            }}
+            aria-label={"scroll right"}
+          >
+            <RightIcon />
+          </Box>
+        </>
+      )}
+
+      {/* 썸네일 리스트 */}
+      <Box
+        ref={scrollerRef}
+        sx={{
+          display: "flex",
+          gap: 4,
+          overflowX: "auto",
+          scrollBehavior: "smooth",
+          pr: 8,
+          pl: 8,
+          "&::-webkit-scrollbar": { height: 8 },
+          "&::-webkit-scrollbar-thumb": {
+            backgroundColor: "rgba(0,0,0,0.15)",
+            borderRadius: 4,
+          },
+        }}
+      >
+        {(routines ?? []).map((r) => (
+          <Box key={r.id} sx={{ minWidth: 240, maxWidth: 240 }}>
+            <Box
+              component={"img"}
+              src={r.thumbnail_path}
+              alt={r.name}
+              sx={{
+                width: 240,
+                height: 240,
+                objectFit: "cover",
+                display: "block",
+                borderRadius: 1.5,
+                backgroundColor: "rgba(0,0,0,0.03)",
+              }}
+            />
+            <Typography
+              variant={"Heading1"}
+              sx={{ mt: 2, textAlign: "center" }}
+            >
+              {r.name}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/app/(with-container)/record/panel/SurveyIntro.tsx
+++ b/src/app/(with-container)/record/panel/SurveyIntro.tsx
@@ -4,7 +4,11 @@ import { Box, Typography } from "@mui/material";
 import SurveyIcon from "@/components/icons/SurveyIcon";
 import useMedia from "@/hooks/useMedia";
 
-export default function SurveyIntro() {
+type SurveyIntroProps = {
+  title?: string;
+};
+
+export default function SurveyIntro({ title }: SurveyIntroProps) {
   const { isPhone } = useMedia();
 
   return (
@@ -16,7 +20,7 @@ export default function SurveyIntro() {
         }}
       />
       <Typography variant={isPhone ? "Headline1" : "Heading1"}>
-        {"수업 기록 작성하기"}
+        {title}
       </Typography>
     </Box>
   );

--- a/src/app/(with-container)/record/panel/server/getRecords.ts
+++ b/src/app/(with-container)/record/panel/server/getRecords.ts
@@ -1,5 +1,10 @@
 import { createAxiosServer } from "@/apis/createAxiosServer";
-import type { RecordItem } from "../../utils/recordUtils";
+import type {
+  RecordItem,
+  RecordDetail,
+  RoutineItem,
+  SurveyItem,
+} from "../../utils/recordUtils";
 import { isAuthError, AuthError } from "@/apis/errors";
 import type { AxiosError } from "axios";
 
@@ -25,8 +30,22 @@ export async function getRecordsServer(): Promise<RecordItem[]> {
   }
 }
 
-export async function getRecordServer(id: number): Promise<RecordItem | null> {
-  const api = await createAxiosServer(); // 서버에서만 실행됨
-  const { data } = await api.get<RecordAPI>("/records");
-  return data?.data?.find((r) => r.recordId === id) ?? null;
+type RecordDetailAPI = {
+  status: number;
+  message: string;
+  data: {
+    record: RecordItem;
+    routines: RoutineItem[];
+    surveys: SurveyItem[];
+  };
+};
+
+export async function getRecordServer(
+  id: number,
+): Promise<RecordDetail | null> {
+  const api = await createAxiosServer();
+  const { data } = await api.get<RecordDetailAPI>(`/records/${id}/surveys`);
+  if (!data?.data?.record) return null;
+  const { record, routines, surveys } = data.data;
+  return { ...record, routines, surveys };
 }

--- a/src/app/(with-container)/record/update/[id]/page.tsx
+++ b/src/app/(with-container)/record/update/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getRecordServer } from "../../panel/server/getRecords";
 import SurveySection from "../../panel/SurveySection";
 import BackActionButton from "../../panel/BackActionButton";
 import SurveyIntro from "../../panel/SurveyIntro";
+import RoutineImage from "../../panel/RoutineImage";
 
 export default async function RecordUpdatePage({
   params,
@@ -19,6 +20,8 @@ export default async function RecordUpdatePage({
 
       <AboutRecording record={currentRecord} title={"수정 중인 수업"} />
 
+      <RoutineImage routines={currentRecord?.routines ?? []} />
+
       <Box
         sx={{
           p: 6,
@@ -28,7 +31,7 @@ export default async function RecordUpdatePage({
           mb: 8,
         }}
       >
-        <SurveyIntro />
+        <SurveyIntro title={"수업 기록 수정하기"} />
 
         <Divider sx={{ my: 3 }} />
 

--- a/src/app/(with-container)/record/utils/recordUtils.ts
+++ b/src/app/(with-container)/record/utils/recordUtils.ts
@@ -2,7 +2,25 @@ import dayjs from "dayjs";
 import "dayjs/locale/ko";
 dayjs.locale("ko");
 
-/* 타입 */
+export type RoutineItem = {
+  id: number;
+  name: string;
+  thumbnail_path: string;
+};
+
+export type SurveyItem = {
+  surveyId: number;
+  name: string;
+  birthDate: string;
+  gender: number;
+  memberRank: number;
+  troubleParts: { target: string }[];
+  attitudeScore: number;
+  abilityScore: number;
+  memo: string;
+  hadTrouble: boolean;
+};
+
 export type RecordItem = {
   recordId: number;
   programId: number;
@@ -15,6 +33,11 @@ export type RecordItem = {
   singingKind: string;
   durationKind: string;
   surveyExist: boolean;
+};
+
+export type RecordDetail = RecordItem & {
+  routines: RoutineItem[];
+  surveys: SurveyItem[];
 };
 
 // 날짜를 반환

--- a/src/app/(with-container)/record/write/[id]/page.tsx
+++ b/src/app/(with-container)/record/write/[id]/page.tsx
@@ -28,7 +28,7 @@ export default async function RecordUpdatePage({
           mb: 8,
         }}
       >
-        <SurveyIntro />
+        <SurveyIntro title={"수업 기록 작성하기"} />
 
         <Divider sx={{ my: 3 }} />
 

--- a/src/components/icons/LeftIcon.tsx
+++ b/src/components/icons/LeftIcon.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Box } from "@mui/material";
+
+export default function LeftIcon() {
+  return (
+    <Box
+      sx={(t) => ({
+        width: 64,
+        height: 64,
+        p: "12px 10px 12px 14px",
+        display: "flex",
+        justifyContent: "flex-end",
+        alignItems: "center",
+        borderRadius: "100px",
+        background: t.palette.static?.white ?? t.palette.common.white,
+        boxShadow: "0 0 8px 0 rgba(12, 13, 13, 0.05)",
+        transform: "rotate(180deg)",
+      })}
+    >
+      <svg
+        xmlns={"http://www.w3.org/2000/svg"}
+        width={"14"}
+        height={"24"}
+        viewBox={"0 0 14 24"}
+        fill={"none"}
+      >
+        <path
+          d={"M2 22L12 12L2 2"}
+          stroke={"#19191A"}
+          strokeWidth={"3"}
+          strokeLinecap={"round"}
+          strokeLinejoin={"round"}
+        />
+      </svg>
+    </Box>
+  );
+}

--- a/src/components/icons/RightIcon.tsx
+++ b/src/components/icons/RightIcon.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Box } from "@mui/material";
+
+export default function RightIcon() {
+  return (
+    <Box
+      sx={(t) => ({
+        width: 64,
+        height: 64,
+        p: "12px 10px 12px 14px",
+        display: "flex",
+        justifyContent: "flex-end",
+        alignItems: "center",
+        borderRadius: "100px",
+        background: t.palette.static?.white ?? t.palette.common.white,
+        boxShadow: "0 0 8px 0 rgba(12, 13, 13, 0.05)",
+      })}
+    >
+      <svg
+        xmlns={"http://www.w3.org/2000/svg"}
+        width={"14"}
+        height={"24"}
+        viewBox={"0 0 14 24"}
+        fill={"none"}
+      >
+        <path
+          d={"M2 22L12 12L2 2"}
+          stroke={"#19191A"}
+          strokeWidth={"3"}
+          strokeLinecap={"round"}
+          strokeLinejoin={"round"}
+        />
+      </svg>
+    </Box>
+  );
+}


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [ ]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?

> 변경된 기능 혹은 주요 작업 내용을 한두 문장으로 요약해주세요.
> 운동 루틴 썸네일 사진 추가와, 페이지 별로 안내 문구(?) 수정 했습니다.
<img width="811" height="649" alt="image" src="https://github.com/user-attachments/assets/8d0af75a-b4b2-4f66-97fc-6b4d0386cd9b" /> 
<img width="551" height="659" alt="image" src="https://github.com/user-attachments/assets/0f4b16e1-23b1-48de-9196-858e0433f388" /> 
<img width="333" height="646" alt="image" src="https://github.com/user-attachments/assets/9f73bab4-3ee5-4cde-bb2b-f8881ac2c33c" />

&nbsp;
### 🔍 작업 상세 내용

- [x]  운동 루틴 썸네일 보이는 ui 추가했습니다.
- [x]  설문 작성하는 페이지, 작성한 설문 확인하는 페이지, 설문 수정하는 페이지에 맞게, "수업 기록 작성하기" "수업 기록 확인하기" "수업 기록 수정하기" 라고 텍스트 바꾸었습니다.

&nbsp;
### 💬 리뷰어에게 전달할 내용 (선택)

> 테스트 방법, 주의 깊게 봐줬으면 하는 부분 등
> "수업 기록 확인하기" 페이지에서 컨트롤 타워 없애는 부분이랑, 각 버튼 클릭 시 다이얼로그 뜨게 하는것은 이따가 작업해보도록 하겠습니다..!!
＞ 음 그리고 저 사진에 모바일 일 때、 하얀 배경 안뜨는거 수정해보겟습니다
