### PR TITLE
[기록] 참여 어르신 수가 0명일 경우에 ui 추가

### DIFF
--- a/src/app/(with-container)/record/detail/[id]/page.tsx
+++ b/src/app/(with-container)/record/detail/[id]/page.tsx
@@ -5,6 +5,7 @@ import SurveySection from "../../panel/SurveySection";
 import BackActionButton from "../../panel/BackActionButton";
 import SurveyIntro from "../../panel/SurveyIntro";
 import RoutineImage from "../../panel/RoutineImage";
+import NoParticipantNotice from "../../panel/NoparticipantNotice";
 
 export default async function RecordDetailPage({
   params,
@@ -13,6 +14,8 @@ export default async function RecordDetailPage({
 }) {
   const { id } = await params;
   const currentRecord = await getRecordServer(parseInt(id));
+
+  const participantCount = currentRecord?.participantCount ?? 0;
 
   return (
     <Box sx={{ display: "grid", gap: 3 }}>
@@ -35,7 +38,11 @@ export default async function RecordDetailPage({
 
         <Divider sx={{ my: 3 }} />
 
-        <SurveySection recordId={Number(id)} mode={"detail"} />
+        {participantCount === 0 ? (
+          <NoParticipantNotice />
+        ) : (
+          <SurveySection recordId={Number(id)} mode={"detail"} />
+        )}
       </Box>
     </Box>
   );

--- a/src/app/(with-container)/record/panel/NoParticipantNotice.tsx
+++ b/src/app/(with-container)/record/panel/NoParticipantNotice.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import WarningAmberRoundedIcon from "@mui/icons-material/WarningAmberRounded";
+import useMedia from "@/hooks/useMedia";
+
+export default function NoParticipantNotice() {
+  const { isPhone } = useMedia();
+
+  return (
+    <Box
+      sx={{
+        py: 6,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 2,
+      }}
+    >
+      <WarningAmberRoundedIcon
+        sx={{ fontSize: 48, color: (t) => t.palette.warning.main }}
+        aria-hidden
+      />
+      <Typography
+        variant={isPhone ? "Headline1" : "Heading1"}
+        sx={{
+          display: "block",
+          textAlign: "center",
+          whiteSpace: "pre-line !important",
+        }}
+      >
+        {"참여한 어르신이 없는 경우,\n개별기록이 제공되지 않습니다."}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/app/(with-container)/record/panel/NoParticipantNotice.tsx
+++ b/src/app/(with-container)/record/panel/NoParticipantNotice.tsx
@@ -26,10 +26,11 @@ export default function NoParticipantNotice() {
         sx={{
           display: "block",
           textAlign: "center",
-          whiteSpace: "pre-line !important",
+          whiteSpace: "pre-line",
         }}
       >
-        {"참여한 어르신이 없는 경우,\n개별기록이 제공되지 않습니다."}
+        {"참여한 어르신이 없는 경우"}
+        <br /> {"개별기록이 제공되지 않습니다."}
       </Typography>
     </Box>
   );

--- a/src/app/(with-container)/record/panel/RecentRecord.tsx
+++ b/src/app/(with-container)/record/panel/RecentRecord.tsx
@@ -25,12 +25,17 @@ export default function RecentRecord({
   const { isTablet, isPhone } = useMedia();
 
   const handleClickCard = () => {
-    if (latest?.surveyExist) {
+    const hasParticipants = (latest?.participantCount ?? 0) > 0;
+
+    if (!hasParticipants) {
       setOpenDialog("alreadyWritten");
       return;
+    }
+
+    if (latest?.surveyExist) {
+      setOpenDialog("alreadyWritten");
     } else {
       setOpenDialog("noSurvey");
-      return;
     }
   };
 

--- a/src/app/(with-container)/record/panel/RecordButton.tsx
+++ b/src/app/(with-container)/record/panel/RecordButton.tsx
@@ -8,10 +8,16 @@ type Props = {
   href: string;
   cta: "자세히 보기" | "작성하기";
   surveysExist: boolean;
+  participantCount?: number;
 };
 
-export default function RecordButton({ href, cta, surveysExist }: Props) {
-  const isDetail = surveysExist;
+export default function RecordButton({
+  href,
+  cta,
+  surveysExist,
+  participantCount = 0,
+}: Props) {
+  const isDetail = participantCount === 0 ? true : surveysExist;
 
   return (
     <Button

--- a/src/app/(with-container)/record/panel/RecordsList.tsx
+++ b/src/app/(with-container)/record/panel/RecordsList.tsx
@@ -89,10 +89,18 @@ export default function RecordsList({ variant, all }: Props) {
           <>
             <Stack sx={{ mt: 3 }}>
               {list.map((it, idx) => {
-                const cta = it.surveyExist ? "자세히 보기" : "작성하기";
-                const href = it.surveyExist
-                  ? `/record/detail/${it.recordId}`
-                  : `/record/write/${it.recordId}`;
+                const hasParticipants = (it.participantCount ?? 0) > 0;
+
+                const cta = !hasParticipants
+                  ? "자세히 보기"
+                  : it.surveyExist
+                    ? "자세히 보기"
+                    : "작성하기";
+
+                const href =
+                  !hasParticipants || it.surveyExist
+                    ? `/record/detail/${it.recordId}`
+                    : `/record/write/${it.recordId}`;
 
                 return (
                   <Box key={it.recordId}>
@@ -107,6 +115,7 @@ export default function RecordsList({ variant, all }: Props) {
                         href={href}
                         cta={cta}
                         surveysExist={it.surveyExist}
+                        participantCount={it.participantCount}
                       />
                     </Stack>
                     {idx < list.length - 1 && <Divider sx={{ my: 3 }} />}

--- a/src/app/(with-container)/record/panel/SurveyActionButton.tsx
+++ b/src/app/(with-container)/record/panel/SurveyActionButton.tsx
@@ -125,18 +125,6 @@ export default function SurveyActionButton({
           >
             <Typography variant={"Heading1"}>{"수정하기"}</Typography>
           </Button>
-          <Button
-            onClick={() => console.log("nothing")}
-            sx={{
-              flex: 1,
-              bgcolor: (t) => t.palette.primary.main,
-              color: (t) => t.palette.static.white,
-              borderRadius: "12px",
-              py: 1.5,
-            }}
-          >
-            <Typography variant={"Heading1"}>{"저장하기"}</Typography>
-          </Button>
         </Box>
       );
     }
@@ -203,24 +191,14 @@ export default function SurveyActionButton({
         );
       case "detail":
         return (
-          <>
-            <CTAButton
-              text={"수정하기"}
-              onClick={openEditConfirm}
-              sx={{
-                bgcolor: (t) => t.palette.fillVariants.colored,
-                color: (t) => t.palette.primary.main,
-              }}
-            />
-            <CTAButton
-              text={"저장하기"}
-              onClick={() => console.log("nothing")}
-              sx={{
-                bgcolor: (t) => t.palette.primary.main,
-                color: (t) => t.palette.static.white,
-              }}
-            />
-          </>
+          <CTAButton
+            text={"수정하기"}
+            onClick={openEditConfirm}
+            sx={{
+              bgcolor: (t) => t.palette.fillVariants.colored,
+              color: (t) => t.palette.primary.main,
+            }}
+          />
         );
       case "update":
         return (

--- a/src/app/(with-container)/record/panel/SurveyElderCard.tsx
+++ b/src/app/(with-container)/record/panel/SurveyElderCard.tsx
@@ -147,7 +147,7 @@ export default function ElderSurveyCard({
           borderRadius: 2,
           bgcolor: t.palette.fillVariants.alternative,
           p: 2,
-          border: `1px solid ${t.palette.borderVariants.normal}`, // 이거 수정해야하나요..??????????????????????????????
+          border: `1px solid ${t.palette.borderVariants.normal}`, // 이거 수정해야하나요? boxShadow 값이 피그마에 없길래...
         })}
       >
         {/* 상단 정보: 모바일 2줄, 그 외 1줄 */}


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [ ]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?

> 변경된 기능 혹은 주요 작업 내용을 한두 문장으로 요약해주세요.
> 참여 어르신 수가 0명일 경우에 생각해야 될 문제들을 해결해보았습니다..

&nbsp;
### 🔍 작업 상세 내용

- [ ]  기록 목록에서 버튼이 무조건 "자세히 보기" 가 되게 하였고
- [ ]  해서 해당 페이지로 접속하면, 어르신들 설문하는 화면이 아닌, "참여한 어르신이 없는 경우,\n개별기록이 제공되지 않습니다." 라는 안내문구가 나오고 있습니다.
- [ ]  또한, recentRecord 파일에서 어르신 수가 0명이면, 설문 여부에 따르는 것이 아닌 무조건 detail을 보는 화면으로 이동하는 모달이 띄어주게 하였고,
- [ ] 이건 저 participantCount와 관련없이, "수정하기" "저장하기" 버튼에서 "저장하기"를 지워달라고 하셔서 없앴습니다.

&nbsp;
### 💬 리뷰어에게 전달할 내용 (선택)

> 테스트 방법, 주의 깊게 봐줬으면 하는 부분 등
> NoParticipantNotice 파일에서 "참여한 어르신이 없는 경우,\n개별기록이 제공되지 않습니다." 이 부분을 제가 pre-line 속성을 주었는데, \n 이 반영이 안되고 있습니다 ㅜㅜ
