### PR TITLE
[운동 탭] 수업 종료 이벤트 전달 안정화

### DIFF
--- a/src/app/(plain)/exercise/class/[id]/panel/WorkoutVideoPlayer.tsx
+++ b/src/app/(plain)/exercise/class/[id]/panel/WorkoutVideoPlayer.tsx
@@ -76,7 +76,10 @@ export default function WorkoutVideoPlaylist({
   const notifyDone = useCallback((): void => {
     const pid = Array.isArray(programId) ? programId[0] : programId;
     notifyClassDone({ programId: pid, seconds });
-    window.close();
+    // 브로드캐스트가 부모 탭에 전달될 시간 확보
+    window.setTimeout(() => {
+      window.close();
+    }, 50);
   }, [programId, seconds]);
 
   const initialIndex = useMemo(() => {
@@ -105,13 +108,7 @@ export default function WorkoutVideoPlaylist({
       let target = next;
 
       if (next >= len) {
-        if (!loop) {
-          // 마지막 영상까지 끝나면 자동으로 완료 처리
-          const pid = Array.isArray(programId) ? programId[0] : programId;
-          notifyClassDone({ programId: pid, seconds });
-          window.close();
-          return;
-        }
+        if (!loop) return notifyDone();
         target = 0;
       } else if (next < 0) {
         target = 0;
@@ -120,7 +117,7 @@ export default function WorkoutVideoPlaylist({
       setIndex(target);
       onIndexChange?.(target, videos[target]);
     },
-    [videos, loop, onIndexChange, programId, seconds],
+    [videos, loop, notifyDone, onIndexChange],
   );
   const { setToastOpen } = useToastStore();
 

--- a/src/app/panel/SenifitThemeProvider.tsx
+++ b/src/app/panel/SenifitThemeProvider.tsx
@@ -100,25 +100,24 @@ declare module "@mui/material/styles" {
     };
   }
 
-  interface PaletteOptions
-    extends Pick<
-      MuiPaletteOptions,
-      | "common"
-      | "primary"
-      | "secondary"
-      | "error"
-      | "warning"
-      | "info"
-      | "success"
-      | "mode"
-      | "contrastThreshold"
-      | "tonalOffset"
-      | "divider"
-      | "background"
-      | "text"
-      | "action"
-      | "grey"
-    > {
+  interface PaletteOptions extends Pick<
+    MuiPaletteOptions,
+    | "common"
+    | "primary"
+    | "secondary"
+    | "error"
+    | "warning"
+    | "info"
+    | "success"
+    | "mode"
+    | "contrastThreshold"
+    | "tonalOffset"
+    | "divider"
+    | "background"
+    | "text"
+    | "action"
+    | "grey"
+  > {
     static?: {
       white?: string;
       black?: string;

--- a/src/components/SenifitToggleButtonGroupField.tsx
+++ b/src/components/SenifitToggleButtonGroupField.tsx
@@ -14,7 +14,9 @@ export interface ISenifitToggleButtonGroupFieldProps<
   T extends string | number | boolean,
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
-> extends Omit<ISenifitToggleButtonGroupProps<T>, "value" | "onChange">,
+>
+  extends
+    Omit<ISenifitToggleButtonGroupProps<T>, "value" | "onChange">,
     Pick<
       UseControllerProps<TFieldValues, TName>,
       "name" | "control" | "rules"

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -22,8 +22,10 @@ export interface IVideoHandle {
   getEl: () => HTMLVideoElement | null;
 }
 
-export interface IVideoPlayerProps
-  extends Omit<React.VideoHTMLAttributes<HTMLVideoElement>, "onTimeUpdate"> {
+export interface IVideoPlayerProps extends Omit<
+  React.VideoHTMLAttributes<HTMLVideoElement>,
+  "onTimeUpdate"
+> {
   src: string;
   length: number;
   poster?: string;

--- a/src/types/ISelect.ts
+++ b/src/types/ISelect.ts
@@ -18,11 +18,10 @@ export interface ISelectOption<T extends TOptionValue> {
 }
 
 /** 공용 Select 베이스 props */
-export interface IBaseSelectProps<T extends TOptionValue>
-  extends Omit<
-    SelectProps<T>,
-    "multiple" | "value" | "onChange" | "renderValue" | "native"
-  > {
+export interface IBaseSelectProps<T extends TOptionValue> extends Omit<
+  SelectProps<T>,
+  "multiple" | "value" | "onChange" | "renderValue" | "native"
+> {
   options: ISelectOption<T>[];
   placeholder?: ReactNode;
   /** 메뉴 Paper / List 개별 커스텀 */
@@ -31,16 +30,18 @@ export interface IBaseSelectProps<T extends TOptionValue>
 }
 
 /** 단일 선택 */
-export interface ISingleSelectProps<T extends TOptionValue>
-  extends IBaseSelectProps<T> {
+export interface ISingleSelectProps<
+  T extends TOptionValue,
+> extends IBaseSelectProps<T> {
   multiple?: false;
   value: T | "";
   onChange: (v: T) => void;
 }
 
 /** 다중 선택 */
-export interface IMultiSelectProps<T extends TOptionValue>
-  extends IBaseSelectProps<T> {
+export interface IMultiSelectProps<
+  T extends TOptionValue,
+> extends IBaseSelectProps<T> {
   multiple: true;
   value: T[];
   onChange: (v: T[]) => void;

--- a/src/types/IToggleButton.ts
+++ b/src/types/IToggleButton.ts
@@ -12,8 +12,10 @@ export interface IResponsiveMaxItems {
 }
 
 /** 개별 토글 버튼 공용 props */
-export interface ISenifitToggleButtonProps
-  extends Omit<MuiButtonProps, "onChange"> {
+export interface ISenifitToggleButtonProps extends Omit<
+  MuiButtonProps,
+  "onChange"
+> {
   /** 버튼 높이 프리셋 */
   sizeVariant?: SizeVariant;
   /** 그룹 내에서 각 버튼을 가변 폭(flex:1)으로 확장할지 여부 */
@@ -68,8 +70,9 @@ export interface IBaseProps<T extends string | number | boolean> {
 }
 
 /** 단일 선택(Exclusive) 모드용 props */
-export interface IExclusiveProps<T extends string | number | boolean>
-  extends IBaseProps<T> {
+export interface IExclusiveProps<
+  T extends string | number | boolean,
+> extends IBaseProps<T> {
   /** true 또는 생략 시 단일 선택 모드 */
   exclusive?: true;
   /** 현재 선택 값 */
@@ -79,8 +82,9 @@ export interface IExclusiveProps<T extends string | number | boolean>
 }
 
 /** 다중 선택(Multi) 모드용 props */
-export interface IMultiProps<T extends string | number | boolean>
-  extends IBaseProps<T> {
+export interface IMultiProps<
+  T extends string | number | boolean,
+> extends IBaseProps<T> {
   /** false일 때만 다중 선택 모드로 동작 */
   exclusive: false;
   /** 현재 선택 값 배열 */

--- a/src/utils/broadcast.ts
+++ b/src/utils/broadcast.ts
@@ -55,16 +55,17 @@ export function notifyClassDone(payload: {
     at: Date.now(),
   };
 
+  // storage 이벤트가 다른 탭(부모 페이지)에 안정적으로 전달되도록 먼저 기록
   try {
-    const bc = new BroadcastChannel(CHANNEL);
-    bc.postMessage(data);
-    bc.close();
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
   } catch {
     // ignore
   }
 
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    const bc = new BroadcastChannel(CHANNEL);
+    bc.postMessage(data);
+    bc.close();
   } catch {
     // ignore
   }


### PR DESCRIPTION
## Summary
- 수업 창이 닫히는 타이밍에 CLASS_DONE 신호가 유실되어 완료 페이지로 이동이 안 되는 케이스를 방지합니다.
- CLASS_DONE를 localStorage에 먼저 기록하고, `window.close()`를 짧게 지연시켜 부모 탭이 안정적으로 수신하도록 했습니다.
- (부수) CI의 prettier/prettier lint 실패를 막기 위해 일부 파일을 CI Prettier 출력과 맞췄습니다.

## Test plan
- [ ] 수업 시작(새 창) → 마지막 영상 종료 → 부모 탭이 `/exercise/done/[id]`로 자동 이동
- [ ] 완료 버튼("종료") 클릭 시에도 동일하게 `/exercise/done/[id]`로 이동
- [ ] `npm run lint -- --quiet` / `npm run typecheck` 통과