### PR TITLE
[ ] 스낵바 노출 시간 조정 및 운동 프로그램 진행 시 스낵바 노출 제거

### DIFF
--- a/src/app/(plain)/exercise/class/[id]/panel/WorkoutVideoPlayer.tsx
+++ b/src/app/(plain)/exercise/class/[id]/panel/WorkoutVideoPlayer.tsx
@@ -8,7 +8,6 @@ import Header from "./Header";
 import { useParams } from "next/navigation";
 import { useTimer } from "@/hooks/useTimer";
 import { notifyClassDone } from "@/utils/broadcast";
-import { useToastStore } from "@/states/useToastStore";
 
 export interface IWorkoutVideo {
   id: number;
@@ -116,17 +115,14 @@ export default function WorkoutVideoPlaylist({
     },
     [videos, loop, onIndexChange],
   );
-  const { setToastOpen } = useToastStore();
 
   const prev = useCallback(() => {
-    setToastOpen({ message: "이전 영상을 재생합니다.", autoHide: "short" });
     go(index - 1);
-  }, [go, index, setToastOpen]);
+  }, [go, index]);
 
   const next = useCallback(() => {
-    setToastOpen({ message: "다음 영상을 재생합니다.", autoHide: "short" });
     go(index + 1);
-  }, [go, index, setToastOpen]);
+  }, [go, index]);
 
   // src 바뀌면 자동 재생 시도(사용자 제스처 이후 연속 재생 안정화)
   useEffect(() => {

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -7,15 +7,27 @@ import { Alert, Snackbar, Typography } from "@mui/material";
 import React from "react";
 
 const Toast = () => {
-  const { message, open, setToastClose } = useToastStore();
+  const { message, open, autoHide, setToastClose } = useToastStore();
   const { isPhone } = useMedia();
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    const duration =
+      autoHideDurationMap[autoHide] || autoHideDurationMap.normal;
+    const timer = setTimeout(() => {
+      setToastClose();
+    }, duration);
+
+    return () => clearTimeout(timer);
+  }, [open, autoHide, setToastClose]);
 
   return (
     <Snackbar
       open={open}
       onClose={setToastClose}
       anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-      autoHideDuration={autoHideDurationMap["normal"]}
+      // autoHideDuration={autoHideDurationMap["normal"]}
       sx={{
         maxWidth: "1200px",
         mx: "auto",

--- a/src/hooks/useVideoPlayer.ts
+++ b/src/hooks/useVideoPlayer.ts
@@ -1,4 +1,3 @@
-import { useToastStore } from "@/states/useToastStore";
 import { useEffect, useState, useCallback } from "react";
 
 const bufferedEnd = (v: HTMLVideoElement) => {
@@ -36,8 +35,6 @@ export function useVideoPlayer(
   const [scrub, setScrub] = useState<number | null>(null);
   const [autoplayBlocked, setAutoplayBlocked] = useState(false);
 
-  const { setToastOpen } = useToastStore();
-
   useEffect(() => {
     const v = videoRef.current;
     if (!v) return;
@@ -48,7 +45,6 @@ export function useVideoPlayer(
     };
     const onPause = () => {
       setPlaying(false);
-      setToastOpen({ message: "영상을 정지했습니다." });
       onPlayStateChange?.(false);
     };
     const onTime = () => {
@@ -80,13 +76,7 @@ export function useVideoPlayer(
       v.removeEventListener("progress", onProg);
       v.removeEventListener("volumechange", onVol);
     };
-  }, [
-    videoRef,
-    onPlayStateChange,
-    onMuteChange,
-    onTimeUpdateSec,
-    setToastOpen,
-  ]);
+  }, [videoRef, onPlayStateChange, onMuteChange, onTimeUpdateSec]);
 
   useEffect(() => {
     const v = videoRef.current;


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 리팩토링 / 코드 개선
- [ ] 의존성 / 환경 설정 변경
- [x] 버그 수정
- [ ] 기타 (하단에 설명)

&nbsp;

### ✨ 어떤 내용인가요?

> 변경된 기능 혹은 주요 작업 내용을 한두 문장으로 요약해주세요.
> 스낵바가 호버와 클릭에 관계없이 3초 동안만 노출되도록 설정
> 운동 프로그램 진행 시에는 스낵바가 등장하지 않도록 설정

&nbsp;

### 🔍 작업 상세 내용

- [ ] 토스트 내부의 스케쥴러 대신 useState를 통해 자체적으로 3초를 계산
- [ ] 영상 재생 시에 Toast 노출을 막기 위해, useToastState를 삭제

&nbsp;

### 💬 리뷰어에게 전달할 내용 (선택)

> 테스트 방법, 주의 깊게 봐줬으면 하는 부분 등
