### PR TITLE
fix: normalize api base and server origin

### DIFF
--- a/src/apis/axiosClient.ts
+++ b/src/apis/axiosClient.ts
@@ -6,6 +6,20 @@ export const axiosClient = axios.create({
   withCredentials: true, // 쿠키 인증이면 필수
 });
 
+axiosClient.interceptors.request.use((config) => {
+  const url = config.url;
+  if (typeof url === "string" && !url.startsWith("http")) {
+    if (!url.startsWith("/api/")) {
+      const base = url.startsWith("/") ? "" : "/";
+      if (!config.baseURL) {
+        // baseURL이 비어있을 때만 /api를 강제로 붙임
+        config.url = `/api${base}${url}`;
+      }
+    }
+  }
+  return config;
+});
+
 axiosClient.interceptors.response.use(
   (res) => res,
   (error) => {

--- a/src/apis/createAxiosServer.ts
+++ b/src/apis/createAxiosServer.ts
@@ -5,7 +5,7 @@ import { headers as nextHeaders } from "next/headers";
 import { AuthError } from "./errors";
 
 const API_PREFIX = normalizePrefix(process.env.NEXT_PUBLIC_API_BASE ?? "/api");
-const SITE_URL = ensureOrigin(process.env.NEXT_PUBLIC_SITE_URL);
+const ENV_SITE_URL = ensureOrigin(process.env.NEXT_PUBLIC_SITE_URL);
 
 const devHttpsAgent =
   process.env.NODE_ENV !== "production"
@@ -13,11 +13,7 @@ const devHttpsAgent =
     : undefined;
 
 function ensureOrigin(v?: string) {
-  if (!v) {
-    throw new Error(
-      "Missing NEXT_PUBLIC_SITE_URL. Set a valid origin like https://senifit.co.kr",
-    );
-  }
+  if (!v) return undefined;
   // 'localhost:3000' 처럼 스킴이 빠진 값이 와도 보정
   const normalized = /^https?:\/\//i.test(v) ? v : `https://${v}`;
   try {
@@ -25,10 +21,15 @@ function ensureOrigin(v?: string) {
     if (!url.hostname) throw new Error("Missing hostname");
     return url.origin;
   } catch {
-    throw new Error(
-      `Invalid NEXT_PUBLIC_SITE_URL: "${v}". Set a valid origin like https://senifit.co.kr`,
-    );
+    return undefined;
   }
+}
+
+function originFromHeaders(h: Headers) {
+  const proto = h.get("x-forwarded-proto") || "https";
+  const host = h.get("x-forwarded-host") || h.get("host");
+  if (!host) return undefined;
+  return `${proto}://${host}`;
 }
 function normalizePrefix(p: string) {
   return p.startsWith("/") ? p : `/${p}`;
@@ -38,11 +39,12 @@ export async function createAxiosServer(opts?: {
   forwardCookies?: boolean; // default: true
   extraHeaders?: Record<string, string | number | boolean | undefined>;
 }): Promise<AxiosInstance> {
-  // 헤더 의존 대신 env 기반으로 절대 baseURL 생성
-  const baseURL = new URL(API_PREFIX, SITE_URL).toString(); // e.g. https://localhost:3000/api
-
   // 쿠키 전달 (SSR 세션 유지용)
   const h = await nextHeaders();
+  // env 우선, 없으면 요청 헤더 기반 origin 사용
+  const siteOrigin =
+    ENV_SITE_URL || originFromHeaders(h) || "https://localhost:3000";
+  const baseURL = new URL(API_PREFIX, siteOrigin).toString();
   const cookie = opts?.forwardCookies === false ? "" : (h.get("cookie") ?? "");
 
   const instance = axios.create({


### PR DESCRIPTION
## Summary
- force client requests to include /api when baseURL is empty
- build server baseURL from env or request headers fallback

## Test plan
- manual: verify /api requests in browser network